### PR TITLE
Modifications to get compiled in msys2 on arm64

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -310,6 +310,12 @@ else:
     )
     env.Append(CFLAGS=["-std=c11"])
 
+if env.get("use_llvm", False):
+    extra_defines += [
+        "HAVE_TIMESPEC_GET",
+        "_UCRT",
+    ]
+
 env.Append(CPPDEFINES=extra_defines)
 env.Append(CPPPATH=".")
 env.Append(CPPPATH="#vulkan/include")

--- a/godot-patches/02_Add_Curly_Braces_nir_to_dxil.c.patch
+++ b/godot-patches/02_Add_Curly_Braces_nir_to_dxil.c.patch
@@ -1,0 +1,18 @@
+diff --git a/godot-mesa/src/microsoft/compiler/nir_to_dxil.c b/godot-mesa/src/microsoft/compiler/nir_to_dxil.c
+index d6c9d06..1e8e9ea 100644
+--- a/godot-mesa/src/microsoft/compiler/nir_to_dxil.c
++++ b/godot-mesa/src/microsoft/compiler/nir_to_dxil.c
+@@ -5083,11 +5083,11 @@ emit_intrinsic(struct ntd_context *ctx, nir_intrinsic_instr *intr)
+    case nir_intrinsic_exclusive_scan:
+       return emit_reduce(ctx, intr);
+ 
+-   case nir_intrinsic_load_constant_non_opt:
++   case nir_intrinsic_load_constant_non_opt: {
+       const struct dxil_value* value = get_src(ctx, &intr->src[0], 0, nir_type_uint);
+       store_dest_value(ctx, &intr->dest, 0, value);
+       return true;
+-
++   }
+    case nir_intrinsic_load_num_workgroups:
+    case nir_intrinsic_load_workgroup_size:
+    default:


### PR DESCRIPTION
These modifications make it possible to compile within a msys2 clangarm64 environment.

Command used to build:
```
    scons use_mingw=True use_llvm=True arch=arm64
```

The patch file prevents this error from occurring:
```
    gcc -o godot-mesa/src/microsoft/compiler/nir_to_dxil.windows.arm64.o -c -std=c11 -O3 -DMINGW_ENABLED -DWINVER=0x0603 -D_WIN32_WINNT=0x0603 -D__MSVCRT_VERSION__=1792 -DHAVE_STRUCT_TIMESPEC -DWINDOWS_NO_FUTEX -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -DPACKAGE_VERSION=\"23.1.0-devel\" -DPACKAGE_BUGREPORT=\"https://gitlab.freedesktop.org/mesa/mesa/-/issues\" -DPIPE_SUBSYSTEM_WINDOWS_USER -D_USE_MATH_DEFINES -DHAVE_TIMESPEC_GET -DHAVE_STRUCT_TIMESPEC -D_UCRT -Igodot-mesa -Igodot-mesa/bin -Igodot-mesa/include -Igodot-mesa/include/GL -Igodot-mesa/include/GLES -Igodot-mesa/include/GLES2 -Igodot-mesa/include/GLES3 -Igodot-mesa/include/KHR -Igodot-mesa/src -Igodot-mesa/src/c11/impl -Igodot-mesa/src/compiler -Igodot-mesa/src/compiler/glsl -Igodot-mesa/src/compiler/nir -Igodot-mesa/src/compiler/nir/__pycache__ -Igodot-mesa/src/compiler/spirv -Igodot-mesa/src/gallium -Igodot-mesa/src/gallium/include -Igodot-mesa/src/gallium/include/pipe -Igodot-mesa/src/mesa -Igodot-mesa/src/mesa/main -Igodot-mesa/src/mesa/program -Igodot-mesa/src/microsoft -Igodot-mesa/src/microsoft/compiler -Igodot-mesa/src/microsoft/spirv_to_dxil -Igodot-mesa/src/util -Igodot-mesa/src/util/format -Igodot-mesa/src/util/format/__pycache__ -Igodot-mesa/src/util/sha1 -Igodot-mesa/src/vulkan -Igodot-mesa/src/vulkan/runtime -Igodot-mesa/src/vulkan/util -Igodot-mesa/generated/src -Igodot-mesa/generated/src/compiler -Igodot-mesa/generated/src/compiler/nir -Igodot-mesa/generated/src/compiler/nir -Igodot-mesa/generated/src/compiler/nir -Igodot-mesa/generated/src/compiler/nir -Igodot-mesa/generated/src/compiler/spirv -Igodot-mesa/generated/src/util/format -I. -Ivulkan/include godot-mesa/src/microsoft/compiler/nir_to_dxil.c
    =====
    godot-mesa/src/microsoft/compiler/nir_to_dxil.c:5087:7: error: expected expression
     5087 |       const struct dxil_value* value = get_src(ctx, &intr->src[0], 0, nir_type_uint);
          |       ^
    godot-mesa/src/microsoft/compiler/nir_to_dxil.c:5088:45: error: use of undeclared identifier 'value'
     5088 |       store_dest_value(ctx, &intr->dest, 0, value);
          |                                             ^
    2 errors generated.

    =====
    scons: *** [godot-mesa/src/microsoft/compiler/nir_to_dxil.windows.arm64.o] Error 1
    scons: building terminated because of errors.
```

With these change I am able to build on a Surface Pro X without any issues.

Afterwords compiling godot itself looks like this:
```
$ scons  mingw_prefix=/clangarm64 LINKFLAGS="-lpng -lembree3.dll -L/clangarm64/lib/" CCFLAGS='-I/clangarm64/include/-v' CC=aarch64-w64-mingw32-gcc CXX=aarch64-w64-mingw32-g++ platform=windows builtin_embree=False builtin_libpng=False d3d12=True mesa_libs=<path to godot-nir-static> dxc_path=<path to dxc> opengl3=False vulkan=False use_volk=False
```

embree, and libpng included in the repo proved to be difficult to compile with. I opted to use the pre compiled versions available through my package manager.

This was a fun challenge, and I hope it is found to be useful.

PS this only worked on the current master of Godot (v4.3.dev.custom_build [13a0d6e9b]), the 4.2 branch would not compile.