### PR TITLE
Manually specify build tools

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -110,7 +110,24 @@ opts.Add(
         map=architecture_aliases,
     )
 )
+opts.Add(
+    BoolVariable(
+        key="platform_tools",
+        help="If true, auto detect platform build tools and override ones passed in via CC, CXX, RC, etc.",
+        default=False,
+    )
+)
 
+opts.Add("CXX", "C++ compiler binary")
+opts.Add("CC", "C compiler binary")
+opts.Add("LINK", "Linker binary")
+opts.Add("AS", "Assembler binary")
+opts.Add("AR", "Archiver binary")
+opts.Add("RANLIB", "Ranlib binary")
+opts.Add("RC", "Resource compiler binary")
+# Set this to something like "${TEMPFILE('$AR rcs $TARGET $SOURCES','$ARCOMSTR')}" if you get errors related to a command being too long. 
+# This is a common error on Windows machines.
+opts.Add("ARCOM", "Custom command used to generate an object file from an assembly-language source file.")
 opts.Add("cppdefines", "Custom defines for the pre-processor")
 opts.Add("ccflags", "Custom flags for both the C and C++ compilers")
 opts.Add("cxxflags", "Custom flags for the C++ compiler")
@@ -118,6 +135,7 @@ opts.Add("cflags", "Custom flags for the C compiler")
 opts.Add("linkflags", "Custom flags for the linker")
 opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files.", "")
 opts.Add(BoolVariable("use_asan", "Use address sanitizer (ASAN) in MSVC", False))
+opts.Add("import_env_vars", "A comma-separated list of environment variables to copy from the outer environment.", "")
 
 # Targets flags tool (optimizations, debug symbols)
 target_tool = Tool("targets", toolpath=["godot-tools"])
@@ -125,6 +143,12 @@ target_tool.options(opts)
 
 opts.Update(env)
 Help(opts.GenerateHelpText(env))
+
+# Copy custom environment variables if set.
+if env["import_env_vars"]:
+    for env_var in str(env["import_env_vars"]).split(","):
+        if env_var in os.environ:
+            env["ENV"][env_var] = os.environ[env_var]
 
 # Process CPU architecture argument.
 if env["arch"] == "":

--- a/godot-tools/macos.py
+++ b/godot-tools/macos.py
@@ -17,13 +17,14 @@ def generate(env):
         print("Only universal, arm64, and x86_64 are supported on macOS. Exiting.")
         Exit()
 
-    if sys.platform == "darwin":
-        # Use clang on macOS by default
-        env["CXX"] = "clang++"
-        env["CC"] = "clang"
-    else:
-        # Use osxcross
-        macos_osxcross.generate(env)
+    if env["platform_tools"]:
+        if sys.platform == "darwin":
+            # Use clang on macOS by default
+            env["CXX"] = "clang++"
+            env["CC"] = "clang"
+        else:
+            # Use osxcross
+            macos_osxcross.generate(env)
 
     if env["arch"] == "universal":
         env.Append(LINKFLAGS=["-arch", "x86_64", "-arch", "arm64"])

--- a/godot-tools/windows.py
+++ b/godot-tools/windows.py
@@ -40,11 +40,12 @@ def generate(env):
 
         env["is_msvc"] = True
 
-        # MSVC, linker, and archiver.
-        msvc.generate(env)
-        env.Tool("msvc")
-        env.Tool("mslib")
-        env.Tool("mslink")
+        if env["platform_tools"]:
+            # MSVC, linker, and archiver.
+            msvc.generate(env)
+            env.Tool("msvc")
+            env.Tool("mslib")
+            env.Tool("mslink")
 
         env.Append(CPPDEFINES=["TYPED_METHOD_BIND", "NOMINMAX"])
         env.Append(CCFLAGS=["/EHsc", "/utf-8"])
@@ -58,13 +59,14 @@ def generate(env):
                 env.AppendUnique(CCFLAGS=["/MD"])
         env.Append(LINKFLAGS=["/WX"])
 
-        if env["use_clang_cl"]:
+        if env["platform_tools"] and env["use_clang_cl"]:
             env["CC"] = "clang-cl"
             env["CXX"] = "clang-cl"
 
     elif (sys.platform == "win32" or sys.platform == "msys") and not env["mingw_prefix"]:
         env["use_mingw"] = True
-        mingw.generate(env)
+        if env["platform_tools"]:
+            mingw.generate(env)
         env.Append(CPPDEFINES=["MINGW_ENABLED"])
         # Don't want lib prefixes
         env["IMPLIBPREFIX"] = ""
@@ -90,18 +92,19 @@ def generate(env):
         elif env["arch"] == "x86_32":
             prefix += "i686"
 
-        if env["use_llvm"]:
-            env["CXX"] = prefix + "-w64-mingw32-clang++"
-            env["CC"] = prefix + "-w64-mingw32-clang"
-            env["AR"] = prefix + "-w64-mingw32-ar"
-            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
-            env["LINK"] = prefix + "-w64-mingw32-clang"
-        else:
-            env["CXX"] = prefix + "-w64-mingw32-g++"
-            env["CC"] = prefix + "-w64-mingw32-gcc"
-            env["AR"] = prefix + "-w64-mingw32-gcc-ar"
-            env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
-            env["LINK"] = prefix + "-w64-mingw32-g++"
+        if env["platform_tools"]:
+            if env["use_llvm"]:
+                env["CXX"] = prefix + "-w64-mingw32-clang++"
+                env["CC"] = prefix + "-w64-mingw32-clang"
+                env["AR"] = prefix + "-w64-mingw32-ar"
+                env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+                env["LINK"] = prefix + "-w64-mingw32-clang"
+            else:
+                env["CXX"] = prefix + "-w64-mingw32-g++"
+                env["CC"] = prefix + "-w64-mingw32-gcc"
+                env["AR"] = prefix + "-w64-mingw32-gcc-ar"
+                env["RANLIB"] = prefix + "-w64-mingw32-ranlib"
+                env["LINK"] = prefix + "-w64-mingw32-g++"
 
         env.Append(CPPDEFINES=["MINGW_ENABLED"])
         env.Append(CCFLAGS=["-O3", "-Wwrite-strings"])


### PR DESCRIPTION
This was done for the same reasons as this PR for godot: ~https://github.com/godotengine/godot/pull/91743~ https://github.com/godotengine/godot/pull/101042

> Currently Godot overrides build tools such as CC and CXX depending on which platform is being targeted.  This adds a boolean to the build process that prevents this from happening.  It helps solve a lot of the pain points that I have been running into in the godot-src project: https://github.com/lange-studios/godot-src
> 
> This allows me to more easily use zig and other tools for cross compilation.  Example:
> 
> ```sh
>   "CC=zig cc -target x86_64-linux-gnu"
>   "CXX=zig c++ -target x86_64-linux-gnu"
>   "LINK=zig c++ -target x86_64-linux-gnu"
>   "AS=zig c++ -target x86_64-linux-gnu"
>   "AR=zig ar"
>   "RANLIB=zig ranlib"
>   "WINDRES=zig rc"
> ```
> 
> And just like that, I can compile godot from any platform zig supports compiling from to any platform zig supports compiling to!  In this case from Windows, Mac, or Linux to Linux! :)
> 
> I'm still testing out things as we build our own game with this tool to different platforms.  So far it is working good!  I'll leave it in draft state while I test things a little more and see what other changes I may need to make to the build process.  I'm doing my best to keep the changes as small as possible.  Please feel free to leave any feedback in the meantime.
> 
> Another thing to note:
> 
> zig handles the linking of libatomic (or so it seems in my tests) so I added a boolean to prevent that from being linked as well.  I have set the default values to mirror exactly how godot currently behaves so as to avoid any breaking changes for existing build processes.

Let me know if there is anything you would like changed :).  Thanks for the awesome tool! :)