### PR TITLE
Add NDEBUG & disable some DXIL optimizations.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -292,6 +292,9 @@ extra_defines = [
     "WINDOWS_NO_FUTEX",
 ]
 
+if env["optimize"] != "debug":
+    extra_defines += ["NDEBUG"]
+
 # These defines are inspired by the Meson build scripts in the original repo.
 extra_defines += [
     "__STDC_CONSTANT_MACROS",

--- a/godot-patches/01_godot_nir_goodies.patch
+++ b/godot-patches/01_godot_nir_goodies.patch
@@ -747,6 +747,40 @@ index bdfbe23..b95ca1d 100644
  };
  
  typedef void (*dxil_msg_callback)(void *priv, const char *msg);
+diff --git a/godot-mesa/src/microsoft/spirv_to_dxil/dxil_spirv_nir.c b/godot-mesa/src/microsoft/spirv_to_dxil/dxil_spirv_nir.c
+index 43de965..8965ecc 100644
+--- a/godot-mesa/src/microsoft/spirv_to_dxil/dxil_spirv_nir.c
++++ b/godot-mesa/src/microsoft/spirv_to_dxil/dxil_spirv_nir.c
+@@ -1068,28 +1068,7 @@ dxil_spirv_nir_passes(nir_shader *nir,
+    NIR_PASS_V(nir, nir_lower_alu_to_scalar, NULL, NULL);
+    NIR_PASS_V(nir, nir_opt_dce);
+    NIR_PASS_V(nir, dxil_nir_lower_double_math);
+-
+-   {
+-      bool progress;
+-      do
+-      {
+-         progress = false;
+-         NIR_PASS(progress, nir, nir_copy_prop);
+-         NIR_PASS(progress, nir, nir_opt_copy_prop_vars);
+-         NIR_PASS(progress, nir, nir_opt_deref);
+-         NIR_PASS(progress, nir, nir_opt_dce);
+-         NIR_PASS(progress, nir, nir_opt_undef);
+-         NIR_PASS(progress, nir, nir_opt_constant_folding);
+-         NIR_PASS(progress, nir, nir_opt_cse);
+-         if (nir_opt_trivial_continues(nir)) {
+-            progress = true;
+-            NIR_PASS(progress, nir, nir_copy_prop);
+-            NIR_PASS(progress, nir, nir_opt_dce);
+-         }
+-         NIR_PASS(progress, nir, nir_lower_vars_to_ssa);
+-         NIR_PASS(progress, nir, nir_opt_algebraic);
+-      } while (progress);
+-   }
++   NIR_PASS_V(nir, nir_lower_vars_to_ssa);
+ 
+    if (conf->declared_read_only_images_as_srvs)
+       NIR_PASS_V(nir, nir_lower_readonly_images_to_tex, true);
 diff --git a/godot-mesa/src/microsoft/spirv_to_dxil/spirv_to_dxil.c b/godot-mesa/src/microsoft/spirv_to_dxil/spirv_to_dxil.c
 index 76cf6b0..819339a 100644
 --- a/godot-mesa/src/microsoft/spirv_to_dxil/spirv_to_dxil.c


### PR DESCRIPTION
Without NDEBUG, the compiled binaries include all assertions and NIR validation passes, which significantly slow down the conversion process.

We can also remove the optimizations applied during the SPIR-V -> NIR pass to save even more time, with barely any impact on the DXIL output.

With both of these changes, conversion times decrease by 2x - 2.5x depending on the project. For example, in the TPS Demo, with both Godot and driver shader caches cleared, the loading time drops from 82 seconds to 33 seconds on my system. For reference, Vulkan is 15 seconds.

Note: Since the validation passes are going to be compiled out, the explicit call to `nir_validate_shader` needs to be removed in Godot. I'll do that in [this PR](https://github.com/godotengine/godot/pull/111762).